### PR TITLE
fix: add wildcard routing and dynamic basepath for Sanity

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,13 +43,7 @@ const router = createBrowserRouter(
         { path: 'login', element: <Login /> },
         { path: 'min-profil', element: <MyProfile /> },
         { path: 'styreportal', element: <BoardPortal /> },
-        {
-          path: 'studio',
-          children: [
-            { index: true, element: <StudioRoute /> },
-            { path: '*', element: <StudioRoute /> },
-          ],
-        },
+        { path: 'studio/*', element: <StudioRoute /> },
         { path: '*', element: <NotFound /> },
       ],
     },

--- a/src/pages/Studio.tsx
+++ b/src/pages/Studio.tsx
@@ -5,10 +5,16 @@ import { visionTool } from '@sanity/vision';
 import { eventType } from '../sanity/schemaTypes/eventType';
 import { homeHeroType } from '../sanity/schemaTypes/heroType';
 
+const appBase = import.meta.env.VITE_BASE ?? '/';
+const basePrefix = appBase === '/' ? '' : appBase.replace(/\/$/, '');
+const studioBasePath = `${basePrefix}/studio`;
+
 const config = defineConfig({
   projectId: '85tc4tb0',
   dataset: 'production',
-  basePath: '/studio',
+  basePath: studioBasePath,
+  title: 'SBSK Studio',
+  subtitle: 'production',
   plugins: [structureTool(), visionTool()],
   schema: {
     types: [homeHeroType, postType, eventType],


### PR DESCRIPTION
# Pull Request

## Description and related issue

Closes #31 

Added a wildcard catch in the router to ensure any route using /studio will be handled internally by Sanity Studio. Also added a dynamic base path for the Sanity config to ensure routing works properly. 