### PR TITLE
chore: move calendar page, add ui improvements

### DIFF
--- a/src/components/sections/CalendarSection.tsx
+++ b/src/components/sections/CalendarSection.tsx
@@ -9,8 +9,10 @@ import ArrowRight from '../../assets/icons/arrows/arrowright.svg?react';
 import type { CalendarEventTypes } from '../../sanity/queryHelpers/events';
 import type { CalendarHeroTypes } from '../../sanity/queryHelpers/calendar-hero';
 import { useNavigate } from 'react-router-dom';
+import { PortableText, toPlainText } from '@portabletext/react';
+import { components } from '../../sanity/editors/portableTextComponents';
 
-interface CalendarProps {
+interface CalendarSectionProps {
   calendarHero?: CalendarHeroTypes;
   events: CalendarEventTypes[];
 }
@@ -24,7 +26,7 @@ const FALLBACK_CALENDAR = {
   imageSourceUrl: 'www.freepik.com',
 };
 
-export default function Calendar({ calendarHero, events }: CalendarProps) {
+export default function CalendarSection({ calendarHero, events }: CalendarSectionProps) {
   return (
     <div className="flex flex-col items-center gap-2 py-6">
       {calendarHero ? <CalendarHero {...calendarHero} /> : <CalendarHero />}
@@ -109,9 +111,10 @@ function EventList({ events }: { events: CalendarEventTypes[] }) {
     }[selectedCategory] || 'bg-darkorange border-black text-white';
 
   const filteredEvents = events.filter((event) => {
+    const contentText = toPlainText(event.content || []);
     const matchesSearch =
       event.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      event.bodyparagraph?.toLowerCase().includes(searchTerm.toLowerCase());
+      contentText.toLowerCase().includes(searchTerm.toLowerCase());
 
     const matchesCategory =
       selectedCategory === 'all' || event.category.toLowerCase() === selectedCategory;
@@ -225,6 +228,7 @@ function EventList({ events }: { events: CalendarEventTypes[] }) {
 
 function EventCard({ calendarEvent }: { calendarEvent: CalendarEventTypes }) {
   const [expandedEvent, setExpandedEvent] = useState(false);
+  console.log(calendarEvent.eventSlug);
   const INTERNAL_ORIGIN = 'https://www.mamf92.github.io/sbsk-website';
   const navigate = useNavigate();
 
@@ -340,8 +344,8 @@ function EventCard({ calendarEvent }: { calendarEvent: CalendarEventTypes }) {
       {expandedEvent && (
         <div className={`bg-${expandColor} flex w-full flex-col p-2 sm:p-6`}>
           <div className={`bg-${backgroundColor} flex flex-col gap-4 p-2 sm:p-6`}>
-            {calendarEvent.bodyparagraph && (
-              <p className="text-sm text-inherit sm:text-base">{calendarEvent.bodyparagraph}</p>
+            {calendarEvent.content && (
+              <PortableText value={calendarEvent.content} components={components} />
             )}
             {calendarEvent.image && (
               <div className="relative h-84 w-full lg:h-100">

--- a/src/loaders/calendar-loader.ts
+++ b/src/loaders/calendar-loader.ts
@@ -1,0 +1,8 @@
+import { calendarHeroLoader } from '../sanity/queryHelpers/calendar-hero';
+import { eventsListLoader } from '../sanity/queryHelpers/events';
+
+export async function calendarLoader() {
+  const { calendarHero } = await calendarHeroLoader();
+  const { events } = await eventsListLoader();
+  return { calendarHero, events };
+}

--- a/src/loaders/home-loader.ts
+++ b/src/loaders/home-loader.ts
@@ -1,12 +1,8 @@
 import { homeHeroLoader } from '../sanity/queryHelpers/home-hero';
 import { postsLoader } from '../sanity/queryHelpers/posts';
-import { calendarHeroLoader } from '../sanity/queryHelpers/calendar-hero';
-import { eventsListLoader } from '../sanity/queryHelpers/events';
 
 export async function homeLoader() {
   const { homeHero } = await homeHeroLoader();
   const { posts } = await postsLoader();
-  const { calendarHero } = await calendarHeroLoader();
-  const { events } = await eventsListLoader();
-  return { homeHero, posts, calendarHero, events };
+  return { homeHero, posts };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,7 @@ import { initTheme } from './utils/theme';
 import StudioRoute from './pages/Studio';
 import { homeLoader } from './loaders/home-loader';
 import { eventsListLoader, eventDetailLoader } from './sanity/queryHelpers/events';
+import { calendarLoader } from './loaders/calendar-loader';
 import { boardPortalLoader } from './loaders/board-portal-loader';
 import { memberPortalLoader } from './loaders/member-portal-loader';
 
@@ -35,7 +36,7 @@ const router = createBrowserRouter(
       element: <App />,
       children: [
         { index: true, element: <Home />, loader: homeLoader },
-        { path: 'kalender', element: <Calendar /> },
+        { path: 'kalender', element: <Calendar />, loader: calendarLoader },
         { path: 'board-game-masters', element: <BoardGameMasters /> },
         { path: 'våre-spill', element: <OurGames /> },
         { path: 'om-oss', element: <AboutUs /> },

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,9 +1,22 @@
+import type { CalendarHeroTypes } from '../sanity/queryHelpers/calendar-hero';
+import type { CalendarEventTypes } from '../sanity/queryHelpers/events';
+import CalendarSection from '../components/sections/CalendarSection';
+import { useLoaderData } from 'react-router-dom';
+
 export default function Calendar() {
+  const { calendarHero, events } = useLoaderData() as {
+    calendarHero: CalendarHeroTypes | null;
+    events: CalendarEventTypes[];
+  };
   return (
     <>
-      <main className="dark:bg-darkestblue min-h-[60vh] bg-white dark:text-white">
-        <div className="text-orange font-heading text-6xl font-bold">Kalender</div>
-      </main>
+      <div className="dark:bg-darkestblue min-h-[60vh] bg-white dark:text-white">
+        {calendarHero ? (
+          <CalendarSection calendarHero={calendarHero} events={events} />
+        ) : (
+          <CalendarSection events={events} />
+        )}
+      </div>
     </>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,29 +1,19 @@
 import { useLoaderData } from 'react-router-dom';
 import HomeHero from '../components/sections/HomeHeroSection';
-import Calendar from '../components/sections/CalendarSection';
 import Posts from '../components/sections/PostsSection';
 import type { PostTypes } from '../sanity/queryHelpers/posts';
 import type { HomeHeroTypes } from '../sanity/queryHelpers/home-hero';
-import type { CalendarHeroTypes } from '../sanity/queryHelpers/calendar-hero';
-import type { CalendarEventTypes } from '../sanity/queryHelpers/events';
 
 export default function Home() {
-  const { posts, homeHero, calendarHero, events } = useLoaderData() as {
+  const { posts, homeHero } = useLoaderData() as {
     posts: PostTypes[];
     homeHero: HomeHeroTypes | null;
-    calendarHero: CalendarHeroTypes | null;
-    events: CalendarEventTypes[];
   };
 
   return (
     <>
       <div className="dark:bg-darkestblue min-h-[60vh] bg-white dark:text-white">
         {homeHero ? <HomeHero {...homeHero} /> : <HomeHero />}
-        {calendarHero ? (
-          <Calendar calendarHero={calendarHero} events={events} />
-        ) : (
-          <Calendar events={events} />
-        )}
         <Posts posts={posts} />
       </div>
     </>

--- a/src/sanity/queryHelpers/events.ts
+++ b/src/sanity/queryHelpers/events.ts
@@ -1,11 +1,12 @@
 import type { LoaderFunctionArgs } from 'react-router-dom';
 import { type SanityImageSource } from '@sanity/image-url';
 import { client } from '../client';
+import type { PortableTextBlock } from 'sanity';
 
 export interface CalendarEventTypes {
   _id: string;
   title: string;
-  bodyparagraph?: string;
+  content?: PortableTextBlock[];
   image?: SanityImageSource;
   eventStartTime: Date;
   eventEndTime: Date;
@@ -15,12 +16,35 @@ export interface CalendarEventTypes {
   links?: { label: string; url: string }[];
 }
 
-const EVENTS_LIST_QUERY = `*[_type == "event"] | order(eventStartTime asc){_id,title, bodyparagraph, image, eventStartTime, eventEndTime, category, eventSlug, location, links}`;
+const EVENTS_LIST_QUERY = `*[
+  _type == "event" && eventEndTime >= now()
+] | order(eventStartTime asc){
+  _id,
+  title,
+  content,
+  image,
+  eventStartTime,
+  eventEndTime,
+  category,
+  "eventSlug": slug.current,
+  location,
+  links
+}`;
 
 const EVENT_BY_SLUG_QUERY = `*[
   _type == "event"
   && slug.current == $slug
-][0]{_id,title, bodyparagraph, eventStartTime, eventEndTime, category, eventSlug, location, links}`;
+][0]{
+  _id,
+  title,
+  content,
+  eventStartTime,
+  eventEndTime,
+  category,
+  "eventSlug": slug.current,
+  location,
+  links
+}`;
 
 export async function eventsListLoader() {
   const events = await client.fetch<CalendarEventTypes[]>(EVENTS_LIST_QUERY);

--- a/src/sanity/schemaTypes/eventType.ts
+++ b/src/sanity/schemaTypes/eventType.ts
@@ -1,4 +1,6 @@
 import { defineField, defineType } from 'sanity';
+import ExternalLink from '../../assets/icons/symbols/external-link.svg?react';
+import AddLink from '../../assets/icons/symbols/add-link.svg?react';
 
 export const eventType = defineType({
   name: 'event',
@@ -18,10 +20,59 @@ export const eventType = defineType({
       validation: (rule) => rule.required(),
     }),
     defineField({
-      title: 'Arrangmenentbeskrivelse',
-      name: 'bodyparagraph',
-      type: 'text',
+      title: 'Arrangementbeskrivelse',
+      name: 'content',
       description: 'Beskrivelse av arrangementet. Valgfritt.',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [
+            { title: 'Normal', value: 'normal' },
+            { title: 'Heading 1', value: 'h2' },
+            { title: 'Heading 2', value: 'h3' },
+          ],
+          lists: [
+            { title: 'Bullet', value: 'bullet' },
+            { title: 'Numbered', value: 'number' },
+          ],
+          marks: {
+            decorators: [
+              { title: 'Strong', value: 'strong' },
+              { title: 'Underline', value: 'underline' },
+              { title: 'Emphasis', value: 'em' },
+            ],
+            annotations: [
+              {
+                name: 'link',
+                type: 'object',
+                title: 'Ekstern lenke',
+                icon: ExternalLink,
+                description: 'Brukes for lenker til eksterne nettsider',
+                fields: [
+                  {
+                    name: 'url',
+                    type: 'url',
+                  },
+                ],
+              },
+              {
+                name: 'internalLink',
+                type: 'object',
+                title: 'Intern lenke',
+                icon: AddLink,
+                description: 'Brukes for lenker til andre sider på nettstedet',
+                fields: [
+                  {
+                    name: 'url',
+                    type: 'url',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
     }),
     defineField({
       title: 'Publiseringsdato',


### PR DESCRIPTION
# Pull Request

## Description and related issue

Closes #61 

Moved Calendar section from Home to Calendar page. 
Updated UI so only ongoing and future events are visible. 
Added Portable Text Editor to events. 